### PR TITLE
selftests/cgroup: Make cpu.max tolerance configurable via env

### DIFF
--- a/tools/testing/selftests/cgroup/lib/cgroup_util.c
+++ b/tools/testing/selftests/cgroup/lib/cgroup_util.c
@@ -21,6 +21,29 @@
 
 bool cg_test_v1_named;
 
+long cgconf_get_env(const char *env_key, long default_value)
+{
+	if (!env_key || !*env_key)
+		return default_value;
+
+	const char *s = getenv(env_key);
+	if (!s || !*s)
+		return default_value;
+
+	errno = 0;
+	char *end = NULL;
+	long v = strtol(s, &end, 10);
+	if (errno || end == s)
+		return default_value;
+
+	while (*end == ' ' || *end == '\t' || *end == '\n' || *end == '\r')
+		end++;
+	if (*end != '\0')
+		return default_value;
+
+	return v;
+}
+
 /* Returns read len on success, or -errno on failure. */
 ssize_t read_text(const char *path, char *buf, size_t max_len)
 {

--- a/tools/testing/selftests/cgroup/lib/include/cgroup_util.h
+++ b/tools/testing/selftests/cgroup/lib/include/cgroup_util.h
@@ -25,6 +25,12 @@ static inline int values_close(long a, long b, int err)
 	return labs(a - b) <= (a + b) / 100 * err;
 }
 
+/*
+* Read an integer value from environment variable `env_key`.
+* If unset or unparsable, return `default_value`.
+*/
+long cgconf_get_env(const char *env_key, long default_value);
+
 extern ssize_t read_text(const char *path, char *buf, size_t max_len);
 extern ssize_t write_text(const char *path, char *buf, ssize_t len);
 

--- a/tools/testing/selftests/cgroup/test_cpu.c
+++ b/tools/testing/selftests/cgroup/test_cpu.c
@@ -649,6 +649,7 @@ static int test_cpucg_max(const char *root)
 	long quota_usec = 1000;
 	long default_period_usec = 100000; /* cpu.max's default period */
 	long duration_seconds = 1;
+	long allowed_tolerance = cgconf_get_env("CPU_MAX", 10);
 
 	long duration_usec = duration_seconds * USEC_PER_SEC;
 	long usage_usec, n_periods, remainder_usec, expected_usage_usec;
@@ -691,7 +692,7 @@ static int test_cpucg_max(const char *root)
 	expected_usage_usec
 		= n_periods * quota_usec + MIN(remainder_usec, quota_usec);
 
-	if (!values_close(usage_usec, expected_usage_usec, 10))
+	if (!values_close(usage_usec, expected_usage_usec, allowed_tolerance))
 		goto cleanup;
 
 	ret = KSFT_PASS;


### PR DESCRIPTION
On older kernels, for instance some older openSuse builds, the cgroup v2 CPU bandwidth accounting/enforcement can exhibit small jitter. With the test setup of quota=1000µs and period=100000µs over 1s, the expected usage is ~10ms, and hardcoded ~10% window can occasionally fail due to coarse accounting rather than a real regression.

This change keeps the upstream default behavior strict but allows CI and downstreams to relax the tolerance using cgconf_get_env().

The patch is adding cgconf_get_env() in cgroup_utils: a tiny helper that reads an integer from an environment variable and falls back to a supplied default if unset/unparsable. Then it uses it in the cpu.max test to derive the percentage tolerance for values_close(). By default the test still uses 10; CI can override, e.g. `CPU_MAX=20 test_cpu`